### PR TITLE
Fix #40: psycopg2.InterfaceError: cursor already closed

### DIFF
--- a/pals/core.py
+++ b/pals/core.py
@@ -144,9 +144,11 @@ class Lock:
         sql = sa.text(f'select pg_advisory_unlock{self.shared_suffix}(:lock_num)')
         with self.conn.begin():
             result = self.conn.execute(sql, {'lock_num': self.lock_num})
-        self.conn.close()
-        self.conn = None
-        return result.scalar()
+        try:
+            return result.scalar()
+        finally:
+            self.conn.close()
+            self.conn = None
 
     def __enter__(self):
         self._acquire()


### PR DESCRIPTION
Fixing a bug (#40) in how the connection & cursor objects are used.

sqlalchemy's `connection.close` will not actually close the underlying DBAPI connection but return it to the connection pool. If nobody else needs the connection, you can happily continue to use cursors created by the connection.

In the `release` method, the cursor is used after the connection is "closed". This leads to problems if you have high pressure on the connection pool.