### PR TITLE
support psycopg3

### DIFF
--- a/pals/core.py
+++ b/pals/core.py
@@ -105,7 +105,7 @@ class Lock:
             self.conn = self.engine.connect()
 
         if blocking:
-            timeout_sql = sa.text('set lock_timeout = :timeout')
+            timeout_sql = sa.text("select set_config('lock_timeout', :timeout :: text, false)")
             with self.conn.begin():
                 self.conn.execute(timeout_sql, {'timeout': acquire_timeout})
 

--- a/pals/tests/test_core.py
+++ b/pals/tests/test_core.py
@@ -10,8 +10,19 @@ import pytest
 
 import pals
 
+try:
+    import psycopg  # noqa: F401
+
+    db_driver = 'postgresql+psycopg'
+except ImportError:
+    db_driver = 'postgresql'
+
+
 # Default URL will work for CI tests
-db_url = os.environ.get('PALS_DB_URL', 'postgresql://postgres:password@localhost/postgres')
+db_url = os.environ.get(
+    'PALS_DB_URL',
+    f'{db_driver}://postgres:password@localhost/postgres'
+)
 
 
 def random_str(length):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'tests': [
             'pytest',
             'pytest-cov',
-            'psycopg2-binary',
+            'psycopg[binary]',
         ],
     }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{38,39,310}-{base,stable}
-    py310-{lowest}
+    py{39,310,311}-{base,stable}
+    py311-{lowest}
     project
 
 [testenv]
@@ -16,7 +16,10 @@ deps =
     -e .[tests]
     stable: -r stable-requirements.txt
     lowest: sqlalchemy<2
+    lowest: psycopg2-binary
 commands =
+    lowest: pip uninstall -y psycopg psycopg-binary
+    stable: pip uninstall -y psycopg psycopg-binary
     pip --version
     # Output installed versions to compare with previous test runs in case a dependency's change
     # breaks things for our build.
@@ -36,7 +39,7 @@ commands =
 
 
 [testenv:project]
-basepython = python3.10
+basepython = python3.11
 skip_install = true
 usedevelop = false
 deps =


### PR DESCRIPTION
refs #42

Also adds python 3.11 in CI, and ensures with tests that both psycopg2 and psycopg3 are working.