### PR TITLE
Only run pg_advisory_unlock_all if necessary.

### DIFF
--- a/pals/core.py
+++ b/pals/core.py
@@ -116,7 +116,6 @@ class Lock:
 
         if self.conn is None:
             self.conn = self.engine.connect()
-            self.parent._taint_connection(self.conn)
 
         if blocking:
             timeout_sql = sa.text("select set_config('lock_timeout', :timeout :: text, false)")
@@ -136,6 +135,7 @@ class Lock:
             # when it acquires the lock.  pg_try_advisory_lock() returns True.
             # If pg_try_advisory_lock() fails, it returns False.
             if retval in (True, ''):
+                self.parent._taint_connection(self.conn)
                 return True
             else:
                 raise AcquireFailure(self.name, 'result was: {retval}')


### PR DESCRIPTION
When using PALs on a shared SQLAlchemy engine, running `pg_advisory_unlock_all` on every connection pool checkin event can cause performance problems.

This PR adds tracking for used DB API connections and will limit the `pg_advisory_unlock_all` to connections that were actually used by PALs.